### PR TITLE
Make compatible with fman 0.3.6

### DIFF
--- a/statusbarextended/__init__.py
+++ b/statusbarextended/__init__.py
@@ -18,7 +18,7 @@ class StatusBarExtended(DirectoryPaneListener):
 
     def refresh(self):
 
-        pane = self.pane.id
+        pane = self.pane.window.get_panes().index(self.pane)
         statusbar_pane = ""
 
         pane_show_hidden_files = load_json('Panes.json')[pane]['show_hidden_files']
@@ -41,7 +41,7 @@ class StatusBarExtended(DirectoryPaneListener):
                         continue
         
         bc = ByteConverter(dir_filesize)
-        if(pane == self.pane.window.get_panes()[0].id):
+        if(self.pane == self.pane.window.get_panes()[0]):
             statusbar_pane += "Pane: Left     "
         else:
             statusbar_pane += "Pane: Right     "


### PR DESCRIPTION
`StatusBarExtended` relies on fman setting `Panes.json` to a dictionary whose keys are `DirectoryPane#id`.

fman 0.3.6 persists the "show hidden files" setting across restarts. To implement this, `Panes.json` had to be changed from a dictionary to a list. Further, `DirectoryPane#id` has been removed from fman's API.

Both of the above changes break the current version of `StatusBarExtended`. This PR fixes it again.