### PR TITLE
Switch to Binary prefixes instead of Decimal

### DIFF
--- a/statusbarextended/__init__.py
+++ b/statusbarextended/__init__.py
@@ -9,7 +9,7 @@ from byteconverter import ByteConverter
 #from PyQt5.QtWidgets import QApplication
 
 def convert_bytes(n):
-    for x in ['B', 'KB', 'MB', 'GB', 'TB']:
+    for x in ['B', 'KiB', 'MiB', 'GiB', 'TiB']:
         if n < 1024.0:
             return "%3.1f %s" % (n, x)
         n /= 1024.0


### PR DESCRIPTION
Since we're dividing by 1024 we should be using the Binary prefix: https://www.wikiwand.com/en/Binary_prefix#/kibi

We're showing Kibibytes (KiB) instead of Kilobytes (KB): https://www.wikiwand.com/en/Kibibyte