### PR TITLE
Allow customizing labels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file
 ## [Unreleased]
   [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.1...HEAD
 
+  - __Fixed__
+    + :beetle: glob meta-characters `[` `]` `*` `?` in paths (e.g. `[A--_B]`) crash glob or lead to wrong results
+
 ## [v0.4.1 — 13.08.2021]
   [ v0.4.1 — 13.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.1
   - __Added__

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,10 @@
 All notable changes to this project will be documented in this file
 
 ## [Unreleased]
-  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.0...HEAD
+  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.1...HEAD
+
+## [v0.4.1 — 13.08.2021]
+  [ v0.4.1 — 13.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.1
   - __Added__
     + :sparkles: User-configurable options for the Folder/File/Size labels 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file
 
 ## [Unreleased]
   [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.3...HEAD
+  - __Added__
+    + :sparkles: `HideDotfile` now also affects the pane list, not just the status bar
 
 ## [v0.4.3 — 14.08.2021]
   [ v0.4.3 — 14.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.3

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,10 @@
 All notable changes to this project will be documented in this file
 
 ## [Unreleased]
-  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.3...HEAD
+  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.4...HEAD
+
+## [v0.4.4 — 15.08.2021]
+  [ v0.4.4 — 15.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.4
   - __Added__
     + :sparkles: `HideDotfile` now also affects the pane list, not just the status bar
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file
 ## [Unreleased]
   [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.2...HEAD
 
+  - __Fixed__
+    + :beetle: `ValueError` on the first `Toggle hidden files` if a pane is _launched_ with hidden files _hidden_
+
 ## [v0.4.2 — 14.08.2021]
   [ v0.4.2 — 14.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.2
   - __Fixed__

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,10 @@
 All notable changes to this project will be documented in this file
 
 ## [Unreleased]
-  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.2...HEAD
+  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.3...HEAD
 
+## [v0.4.3 — 14.08.2021]
+  [ v0.4.3 — 14.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.3
   - __Fixed__
     + :beetle: `ValueError` on the first `Toggle hidden files` if a pane is _launched_ with hidden files _hidden_
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,10 @@
 All notable changes to this project will be documented in this file
 
 ## [Unreleased]
-  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.1...HEAD
+  [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.2...HEAD
 
+## [v0.4.2 — 14.08.2021]
+  [ v0.4.2 — 14.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.2
   - __Fixed__
     + :beetle: glob meta-characters `[` `]` `*` `?` in paths (e.g. `[A--_B]`) crash glob or lead to wrong results
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file
 
 ## [Unreleased]
   [ Unreleased]: https://github.com/kek91/StatusBarExtended/compare/v0.4.0...HEAD
+  - __Added__
+    + :sparkles: User-configurable options for the Folder/File/Size labels 
+
+        |     Option    	|  Default                 	|                  Description              	|
+        | :-------------	| :-----------------------:	| :-----------------------------------------	|
+        | Label         	| `Dirs:` `Files:` `Size:` 	|  `Folder`/`File`/`Size` labels            	|
+        | Hide0Label    	| `True`                   	|  Hide labels when 0 folders/files           |
 
 ## [v0.4.0 — 13.08.2021]
   [ v0.4.0 — 13.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -21,22 +21,24 @@ Aligns indicator positions to avoid "jitter" on selection/navigation
 
 Allows a user to configure all the options via the `configure_status_bar_extended` command aliased as `StatusBarExtended: configure` in the Command Palette:
 
-  |     Option    	|  Default   	|                  Description                                                	|
-  | :-------------	| :--------: 	| :-----------------------------------------                                  	|
-  | Enabled       	| `True`     	|  Enable or disable this plugin                                              	|
-  | SizeDivisor   	| `1024`     	|  File size format: decimal (1k=1000=10³) or binary (1k=1024=2¹⁰)            	|
-  | MaxGlob       	| `5000`     	|  Skip folders with as many items (folders+files)                            	|
-  | SymbolPane    	| `◧` `◨`    	|  `Left`/`Right` pane symbol                                                 	|
-  | SymbolHiddenF 	| `◻` `◼`    	|  Hidden files `Shown`/`Hidden` symbol (__tip__: try `👁` `👀👓` `✓✗` `◎◉` `🐵🙈`)	|
-  | HideDotfile   	| `False`    	|  Treat .dotfiles as hidden files on Windows                                 	|
-  | Justify       	| `5` `5` `7`	|  Minimum width of the `Folder`/`File`/`Size` values, e.g.<br>5,321<br>   21 	|
+  |     Option    	|  Default                       	|                  Description                                               |
+  | :-------------	| :-----------------------------:	| :------------------------------------------------------------------------- |
+  | Enabled       	| `True`                         	|  Enable or disable this plugin                                             |
+  | SizeDivisor   	| `1024`                         	|  File size format: decimal (1k=1000=10³) or binary (1k=1024=2¹⁰)           |
+  | MaxGlob       	| `5000`                         	|  Skip folders with as many items (folders+files)                           |
+  | Label         	| `Dirs:`<br>`Files:`<br>`Size:` 	|  `Folder`/`File`/`Size` labels<br>(__tip__: try `🗀` `🗁` `🖿` `📁` `📂` `📝`) |
+  | Hide0Label    	| `True`                         	|  Hide labels when 0 folders/files                                          |
+  | SymbolPane    	| `◧` `◨`                        	|  `Left`/`Right` pane symbol                                                |
+  | SymbolHiddenF 	| `◻` `◼`                        	|  Hidden files `Shown`/`Hidden` symbol<br>(__tip__: try `👁` `👀👓` `✓✗` `◎◉` `🐵🙈`) |
+  | HideDotfile   	| `False`                        	|  Treat .dotfiles as hidden files on Windows                                 |
+  | Justify       	| `5` `5` `7`                    	|  Minimum width of the `Folder`/`File`/`Size` values, e.g.<br>5,321<br>   21 |
 
 
 **Preview**
 
 |       Status Bar without selection       |        Status Bar with selection         |
 | :--------------------------------------: | :--------------------------------------: |
-| ![Screenshot macOS 10 v0.3.0](fman-plugin-statusbarextended-v0.4.0.png) | ![Screenshot macOS 10 v0.3.0-selection](fman-plugin-statusbarextended-select-v0.4.0.png) |
+| ![Screenshot macOS 10 v0.4.0](fman-plugin-statusbarextended-v0.4.0.png) | ![Screenshot macOS 10 v0.4.0-selection](fman-plugin-statusbarextended-select-v0.4.0.png) |
 
 |       Status Bar alignment       |
 | :------------------------------: |
@@ -46,5 +48,5 @@ __Known issues__
 
 - fman raises `ValueError` on the first `Toggle hidden files` if a pane is _launched_ with hidden files _hidden_ (and status bar is not updated this one time) (__tip__: you might be able to conveniently close the error warning window with the same keybind you toggled hidden files with)
 - Status bar is NOT updated when _switching panes_ with a _mouse_ since plugins can't notice a pane switch due to a lack of the [necessary APIs](https://github.com/fman-users/fman/issues/292#issuecomment-360036718)
-- Alignment of indicators only works for _monospaced_ (fixed-width) fonts since it's currently implemented using regular spaces (__tip__: you can change this font in your `Theme.css` file `.statusbar{font-family:"yourMonospacedFont"}`). And even then fancy icons/emojis might slightly break it
+- Alignment of indicators only works for _monospaced_ (fixed-width) fonts since it's currently implemented using regular spaces (__tip__: you can change this font in your `Theme.css` file `.statusbar{font-family:"yourMonospacedFont"}`). And even then fancy icons/emojis might slightly break it (__tip__: setting `Hide0Label` to `False` might help)
 - On launch the right pane is ignored in the status bar udpate to improve performance since fman always activates the left one (and doesn't have an API to let a plugin know which pane is the active one)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Allows a user to configure all the options via the `configure_status_bar_extende
   | Hide0Label    	| `True`                         	|  Hide labels when 0 folders/files                                          |
   | SymbolPane    	| `◧` `◨`                        	|  `Left`/`Right` pane symbol                                                |
   | SymbolHiddenF 	| `◻` `◼`                        	|  Hidden files `Shown`/`Hidden` symbol<br>(__tip__: try `👁` `👀👓` `✓✗` `◎◉` `🐵🙈`) |
-  | HideDotfile   	| `False`                        	|  Treat .dotfiles as hidden files on Windows                                 |
+  | HideDotfile   	| `False`                        	|  Treat .dotfiles as hidden files on Windows (also affects the pane view)   |
   | Justify       	| `5` `5` `7`                    	|  Minimum width of the `Folder`/`File`/`Size` values, e.g.<br>5,321<br>   21 |
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Allows a user to configure all the options via the `configure_status_bar_extende
 
 __Known issues__
 
-- fman raises `ValueError` on the first `Toggle hidden files` if a pane is _launched_ with hidden files _hidden_ (and status bar is not updated this one time) (__tip__: you might be able to conveniently close the error warning window with the same keybind you toggled hidden files with)
 - Status bar is NOT updated when _switching panes_ with a _mouse_ since plugins can't notice a pane switch due to a lack of the [necessary APIs](https://github.com/fman-users/fman/issues/292#issuecomment-360036718)
 - Alignment of indicators only works for _monospaced_ (fixed-width) fonts since it's currently implemented using regular spaces (__tip__: you can change this font in your `Theme.css` file `.statusbar{font-family:"yourMonospacedFont"}`). And even then fancy icons/emojis might slightly break it (__tip__: setting `Hide0Label` to `False` might help)
 - On launch the right pane is ignored in the status bar udpate to improve performance since fman always activates the left one (and doesn't have an API to let a plugin know which pane is the active one)

--- a/statusbarextended/__init__.py
+++ b/statusbarextended/__init__.py
@@ -6,6 +6,7 @@ from fman.url import as_url, as_human_readable as as_path
 from fman.fs import is_dir, query
 from core.commands.util import is_hidden # works on file_paths, not urls
 import glob
+import re
 from byteconverter import ByteConverter
 #from PyQt5.QtWidgets import QApplication
 import statusbarextended_config as SBEcfg
@@ -27,15 +28,16 @@ class StatusBarExtended(DirectoryPaneListener):
                                  cfg['SymbolHiddenF'][1]
         cur_dir_url      = self.pane.get_path()
         current_dir      = as_path(cur_dir_url)
+        current_dir_gnorm= re.sub(r'(?P<bracket>\[|\]|\?|\*)',r'[\g<bracket>]',current_dir) # bracket the brackets, asterisks and question marks in paths to match them literaly instead of treating them as special globl characters
         dir_folders      = 0
         dir_files        = 0
         dir_filesize     = 0
-        dir_files_in_dir      = glob.glob(current_dir + "/*")
+        dir_files_in_dir      = glob.glob(current_dir_gnorm + "/*")
         if PLATFORM == 'Windows' and not cfg['HideDotfile']:
             # .dotfiles=regular (always shown unless have a 'hidden' attr)
-            dir_files_in_dir += glob.glob(current_dir + "/.*")
+            dir_files_in_dir += glob.glob(current_dir_gnorm + "/.*")
         elif cfg_show_hidden_files: # .dotfile=hidden (internal option shows)
-            dir_files_in_dir += glob.glob(current_dir + "/.*")
+            dir_files_in_dir += glob.glob(current_dir_gnorm + "/.*")
         f_url            = ""
         aboveMax         = False
 

--- a/statusbarextended/__init__.py
+++ b/statusbarextended/__init__.py
@@ -74,32 +74,41 @@ class StatusBarExtended(DirectoryPaneListener):
         jFd  = cfg['Justify']['folder']
         jFl  = cfg['Justify']['file']
         jSz  = cfg['Justify']['size']
+        lFd  = cfg['Label'  ]['folder']+' '
+        lFl  = cfg['Label'  ]['file']  +' '
+        lSz  = cfg['Label'  ]['size']  +' '
+        if cfg['Hide0Label'] == True:
+            lFd_sp = ''.rjust(len(lFd),' ')
+            lFl_sp = ''.rjust(len(lFl),' ')
+        else:
+            lFd_sp = lFd
+            lFl_sp = lFl
         dir_foldK = str("{0:,}".format(dir_folders)) # to ','→' ' add .replace(',', ' ')
         dir_fileK = str("{0:,}".format(dir_files))
         if(self.pane == panes[0]):
             statusbar_pane      += cfg['SymbolPane'][0]
         else:
             statusbar_pane      += cfg['SymbolPane'][1]
-        statusbar_pane          += "   "     + pane_show_hidden_files    + "     "
+        statusbar_pane          += "   "    + pane_show_hidden_files    + "     "
         if     dir_folders > 0:
-            statusbar_pane      += "Dirs: "  + dir_foldK.rjust(jFd, ' ') + "  "
+            statusbar_pane      += lFd      + dir_foldK.rjust(jFd, ' ') + "  "
             if dir_folders <= 9999:
-                statusbar_pane  += " "
+                statusbar_pane  +=                                           " "
         elif aboveMax:
-            statusbar_pane      += "Dirs  "  +     '+  '.rjust(jFd, ' ') + "   "
+            statusbar_pane      += lFd      +     ' + '.rjust(jFd, ' ') + "   "
         else:
-            statusbar_pane      += "      "  +        ''.rjust(jFd, ' ') + "   "
+            statusbar_pane      += lFd_sp   +        ''.rjust(jFd, ' ') + "   "
         if     dir_files > 0:
-            statusbar_pane      += "Files: " + dir_fileK.rjust(jFl, ' ') + "   "
+            statusbar_pane      += lFl      + dir_fileK.rjust(jFl, ' ') + "   "
             if dir_files <= 9999:
-                statusbar_pane  += " "
+                statusbar_pane  +=                                            " "
         elif aboveMax:
-            statusbar_pane      += "Files >" +      maxG.rjust(jFl, ' ') + "    "
+            statusbar_pane      += lFl+">"  +      maxG.rjust(jFl, ' ') + "    "
         else:
-            statusbar_pane      += "       " +        ''.rjust(jFl, ' ') + "    "
+            statusbar_pane      += lFl_sp   +        ''.rjust(jFl, ' ') + "    "
         if not aboveMax:
-            statusbar_pane      += "  Size: "+       bcc.rjust(jSz, ' ') + "   "
-            #        to align with "∑ Size: "
+            statusbar_pane      += "  "+lSz +       bcc.rjust(jSz, ' ') + "   "
+            #        to align with "∑ "
 
         show_status_message(statusbar_pane, 5000)
 
@@ -134,22 +143,31 @@ class StatusBarExtended(DirectoryPaneListener):
             jFd = cfg['Justify']['folder']
             jFl = cfg['Justify']['file']
             jSz = cfg['Justify']['size']
+            lFd = cfg['Label'  ]['folder']+' '
+            lFl = cfg['Label'  ]['file']  +' '
+            lSz = cfg['Label'  ]['size']  +' '
+            if cfg['Hide0Label'] == True:
+                lFd_sp = ''.rjust(len(lFd),' ')
+                lFl_sp = ''.rjust(len(lFl),' ')
+            else:
+                lFd_sp = lFd
+                lFl_sp = lFl
             dir_foldK  = "{0:,}".format(dir_folders)
             dir_fileK  = "{0:,}".format(dir_files)
             statusbar  = "Selected* "
             if     dir_folders > 0:
-                statusbar      += "Dirs: "   + dir_foldK.rjust(jFd, ' ') + "  "
+                statusbar      += lFd      + dir_foldK.rjust(jFd, ' ') + "  "
                 if dir_folders <= 9999:
-                    statusbar  += " "
+                    statusbar  +=                                           " "
             else:
-                statusbar      += "      "   +        ''.rjust(jFd, ' ') + "   "
+                statusbar      += lFd_sp   +        ''.rjust(jFd, ' ') + "   "
             if     dir_files > 0:
-                statusbar      += "Files: "  + dir_fileK.rjust(jFl, ' ') + "   "
+                statusbar      += lFl      + dir_fileK.rjust(jFl, ' ') + "   "
                 if dir_files <= 9999:
                     statusbar  += " "
             else:
-                statusbar      += "       "  +        ''.rjust(jFl, ' ') + "    "
-            statusbar          += "∑ Size: " +       bcc.rjust(jSz, ' ') + "   "
+                statusbar      += lFl_sp   +        ''.rjust(jFl, ' ') + "    "
+            statusbar          += "∑ "+lSz +       bcc.rjust(jSz, ' ') + "   "
             show_status_message(statusbar)
 
         else:

--- a/statusbarextended_config/__init__.py
+++ b/statusbarextended_config/__init__.py
@@ -525,7 +525,10 @@ class ViewConfigurationStatusBarExtended(ApplicationCommand):
                     cfg_fmt += '  ' + subkey +'\t  =  '+ cfgCurrent[ 'Label'][subkey] +'\t'
                     cfg_fmt +=                           cfg.Default['Label'][subkey] +'\n'
             elif key in ('Justify'):
-                cfg_fmt += key +'\t  =  '+ " ".join(str(v) for v in cfgCurrent['Justify'].values()) + "\t"+" ".join(str(v) for v in cfg.Default['Justify'].values()) +'\n'
+                cfg_fmt += key +'\n'
+                for subkey in cfg.Default['Justify']:
+                    cfg_fmt+='  '+subkey+'\t  =  '+str(cfgCurrent[ 'Justify'][subkey]) +'\t'
+                    cfg_fmt+=                      str(cfg.Default['Justify'][subkey]) +'\n'
             else:
                 cfg_fmt += key +'\t  =  '+ str(cfgCurrent[key]) + "\t"+str(cfg.Default[key]) +'\n'
         show_alert(cfg_fmt)

--- a/statusbarextended_config/__init__.py
+++ b/statusbarextended_config/__init__.py
@@ -78,7 +78,7 @@ class SingletonConfig(object):
             if corrupt_count: # delete corrupt config files with the user's permission
                 prompt_msg_full += "Please enter 'y' or 'yes' or '1' (without the quotes) to delete " + str(corrupt_count) + " corrupt plugin config file" \
                     + ("\n" if corrupt_count==1 else "s\n") \
-                    + "with incompatible data type " + str(type(cfgCurrent)) + '\n'\
+                    + "with an incompatible data type " + str(type(cfgCurrent)) + '\n'\
                     + "(all settings will be reset to their defaults)\n"
                 for corrupt_file_dict in corrupt_config:
                     prompt_msg_full += '\n' + corrupt_file_dict['prompt_msg'] + '\n'

--- a/statusbarextended_config/__init__.py
+++ b/statusbarextended_config/__init__.py
@@ -26,6 +26,11 @@ class SingletonConfig(object):
         cls.Default['Enabled']      = True      # enable plugin
         cls.Default['SizeDivisor']  = 1024.0    # binary file sizes
         cls.Default['MaxGlob']      = 5000      # skip large folders with as many items; 0=∞
+        cls.Default['Label']        = odict({   # labels
+                    'folder'        : 'Dirs:' ,
+                    'file'          : 'Files:' ,
+                    'size'          : 'Size:' })
+        cls.Default['Hide0Label']   = True      # hide labels when 0 folders/files
         cls.Default['SymbolPane']   = ['◧','◨'] # Left/Right
         cls.Default['SymbolHiddenF']= ['◻','◼'] # Show/Hide hidden files
         cls.Default['HideDotfile']  = False     # hide non-hidden dotfiles on Windows
@@ -175,10 +180,12 @@ class ConfigureStatusBarExtended(ApplicationCommand):
             + "&1. \t&Enabled\t\t"     + "Enable/Disable this plugin"                   +'\n'\
             + "&2. \tSize&Divisor\t"   + "File size format: decimal or binary"          +'\n'\
             + "&3. \tMax&Glob\t\t"     + "Skip folders with as many items"              +'\n'\
-            + "&4. \tSymbol&Pane\t"    + "Left/Right pane symbol"                       +'\n'\
-            + "&5. \tSymbol&HiddenF\t" + "Hidden files Shown/Hidden symbol"             +'\n'\
-            + "&6. \tHideD&otfile\t"   + "Treat .dotfiles as hidden files on Windows"   +'\n'\
-            + "&7. \t&Justify\t\t"     + "Minimum width of the Folder/File/Size values" +'\n'\
+            + "&4. \t&Label\t\t"       + "Labels for the Folder/File/Size values"       +'\n'\
+            + "&5. \tHide0La&bel\t"    + "Hide labels when 0 folders/files"             +'\n'\
+            + "&6. \tSymbol&Pane\t"    + "Left/Right pane symbol"                       +'\n'\
+            + "&7. \tSymbol&HiddenF\t" + "Hidden files Shown/Hidden symbol"             +'\n'\
+            + "&8. \tHideD&otfile\t"   + "Treat .dotfiles as hidden files on Windows"   +'\n'\
+            + "&9. \t&Justify\t\t"     + "Minimum width of the Folder/File/Size values" +'\n'\
             + '\n'
         value_new, ok = show_prompt(prompt_msg)
         if not ok:
@@ -190,13 +197,17 @@ class ConfigureStatusBarExtended(ApplicationCommand):
             self.setSizeDivisor(  cfg.Default['SizeDivisor'])
         if any(x in value_new.casefold() for x in ('3','g','0','all')):
             self.setMaxGlob(      cfg.Default['MaxGlob'])
-        if any(x in value_new.casefold() for x in ('4','p','0','all')):
+        if any(x in value_new.casefold() for x in ('4','l','0','all')):
+            self.setLabel(        cfg.Default['Label'])
+        if any(x in value_new.casefold() for x in ('5','b','0','all')):
+            self.setHide0Label(   cfg.Default['Hide0Label'])
+        if any(x in value_new.casefold() for x in ('6','p','0','all')):
             self.setSymbolPane(   cfg.Default['SymbolPane'])
-        if any(x in value_new.casefold() for x in ('5','h','0','all')):
+        if any(x in value_new.casefold() for x in ('7','h','0','all')):
             self.setSymbolHiddenF(cfg.Default['SymbolHiddenF'])
-        if any(x in value_new.casefold() for x in ('6','o','0','all')):
+        if any(x in value_new.casefold() for x in ('8','o','0','all')):
             self.setHideDotfile(  cfg.Default['HideDotfile'])
-        if any(x in value_new.casefold() for x in ('7','j','0','all')):
+        if any(x in value_new.casefold() for x in ('9','j','0','all')):
             self.setJustify(      cfg.Default['Justify'])
         cfg.saveConfig(self.cfgCurrent)
         run_application_command('view_configuration_status_bar_extended')
@@ -278,6 +289,71 @@ class ConfigureStatusBarExtended(ApplicationCommand):
                 show_alert("You entered\n" + value_new +'\n'\
                     + "but I was expecting a non-negative integer 0,1,2,3–∞")
         self.cfgCurrent['MaxGlob'] = int(value_new)
+
+    def setLabel(self, value_default):
+        value_cfg_in    = self.cfgCurrent['Label']
+        value_cfg       = " ".join(val for val in  value_cfg_in.values())
+        val_def_fmt     = " ".join(val for val in value_default.values())
+        prompt_msg      = "Please enter three words/symbols, separated by space, to set label names for" +'\n'\
+            + "the folder, file, and size indicators respectively." +'\n'\
+            + "or enter '0' to restore an individual default" +'\n'\
+            + "or leave the field empty to restore all the defaults ("+val_def_fmt+"):"
+        selection_start = 0
+        selection_end   = 0
+        value_new       = ''
+        value_new_list  = []
+        _len            = len(value_new_list)
+        len_def         = len(value_default)
+        while _len != len_def:
+            value_new, ok = show_prompt(prompt_msg, value_cfg, selection_start, selection_end)
+            value_cfg = value_new # preserve user input on multiple edits
+            if not ok:
+                show_status_message("StatusBarExtended: setup canceled")
+                return
+            if value_new.strip(' ') == '':
+                self.cfgCurrent['Label'] = value_default
+                return
+            value_new_nosp = ' '.join(value_new.split()) # replace multiple spaces with 1
+            value_new_list = value_new_nosp.split(' ')   # split by space
+            _len = len(value_new_list)
+            if _len != len_def:
+                show_alert("You entered\n" + value_new +'\n'\
+                    + "I parsed it as " + str(value_new_list) + " with " + str(_len) + " element" + ("" if _len==1 else "s") +'\n'\
+                    + "but was expecting " + str(len_def) + " elements")
+        for i, key in enumerate(value_default):
+            if value_new_list[i] == '0':
+                self.cfgCurrent['Label'][key] = value_default[key]
+            else:
+                self.cfgCurrent['Label'][key] = value_new_list[i]
+
+    def setHide0Label(self, value_default):
+        _t      = ('1', 't', 'true')
+        _f      = ('0', 'f', 'false')
+        _tsep   = "'" + "' or '".join(_t) + "'"
+        _fsep   = "'" + "' or '".join(_f) + "'"
+        _accept = (_t + _f)
+        value_cfg       = str(self.cfgCurrent['Hide0Label'])
+        prompt_msg      = "Please enter " +_tsep+ " to hide labels when 0 Folders/Files" +'\n'\
+            + "or " +_fsep+ " to keep them visible" +'\n'\
+            + "or leave the field empty to restore the default ("+str(value_default) +'):'
+        selection_start = 0
+        value_new       = ''
+        value_new_fmt   = value_new.casefold()
+        while value_new_fmt not in _accept:
+            value_new, ok = show_prompt(prompt_msg, value_cfg, selection_start)
+            value_cfg = value_new # preserve user input on multiple edits
+            if not ok:
+                show_status_message("StatusBarExtended: setup canceled")
+                return
+            if value_new.strip(' ') == '':
+                self.cfgCurrent['Hide0Label'] = value_default
+                return
+            value_new_fmt = value_new.casefold()
+            if value_new_fmt not in _accept:
+                show_alert("You entered\n" + value_new +'\n'\
+                    + "I parsed it as " + value_new_fmt +'\n'\
+                    + "but the only acceptable values are:\n" +_tsep+ "\n" +_fsep)
+        self.cfgCurrent['Hide0Label'] = True if value_new_fmt in _t else False
 
     def setSymbolPane(self, value_default):
         value_cfg       = " ".join(self.cfgCurrent['SymbolPane'])
@@ -443,6 +519,11 @@ class ViewConfigurationStatusBarExtended(ApplicationCommand):
                 cfg_fmt += key +'\t  =  '+ " ".join(cfgCurrent[key]) + "\t"+" ".join(cfg.Default[key]) +'\n'
             elif key in ('SymbolHiddenF'):
                 cfg_fmt += key +    '='  + " ".join(cfgCurrent[key]) + "\t"+" ".join(cfg.Default[key]) +'\n'
+            elif key in ('Label'):
+                cfg_fmt += key +'\n'
+                for subkey in cfg.Default['Label']:
+                    cfg_fmt += '  ' + subkey +'\t  =  '+ cfgCurrent[ 'Label'][subkey] +'\t'
+                    cfg_fmt +=                           cfg.Default['Label'][subkey] +'\n'
             elif key in ('Justify'):
                 cfg_fmt += key +'\t  =  '+ " ".join(str(v) for v in cfgCurrent['Justify'].values()) + "\t"+" ".join(str(v) for v in cfg.Default['Justify'].values()) +'\n'
             else:

--- a/statusbarextended_config/__init__.py
+++ b/statusbarextended_config/__init__.py
@@ -178,13 +178,13 @@ class ConfigureStatusBarExtended(ApplicationCommand):
             + "# \tOption \t\tDescription" +'\n'\
             + "&0. \t&a&l&l\t\t"       + "Configure all the options"                    +'\n'\
             + "&1. \t&Enabled\t\t"     + "Enable/Disable this plugin"                   +'\n'\
-            + "&2. \tSize&Divisor\t"   + "File size format: decimal or binary"          +'\n'\
+            + "&2. \t&SizeDivisor\t"   + "File size format: decimal or binary"          +'\n'\
             + "&3. \tMax&Glob\t\t"     + "Skip folders with as many items"              +'\n'\
             + "&4. \t&Label\t\t"       + "Labels for the Folder/File/Size values"       +'\n'\
             + "&5. \tHide0La&bel\t"    + "Hide labels when 0 folders/files"             +'\n'\
             + "&6. \tSymbol&Pane\t"    + "Left/Right pane symbol"                       +'\n'\
             + "&7. \tSymbol&HiddenF\t" + "Hidden files Shown/Hidden symbol"             +'\n'\
-            + "&8. \tHideD&otfile\t"   + "Treat .dotfiles as hidden files on Windows"   +'\n'\
+            + "&8. \tHide&Dotfile\t"   + "Treat .dotfiles as hidden files on Windows"   +'\n'\
             + "&9. \t&Justify\t\t"     + "Minimum width of the Folder/File/Size values" +'\n'\
             + '\n'
         value_new, ok = show_prompt(prompt_msg)
@@ -193,7 +193,7 @@ class ConfigureStatusBarExtended(ApplicationCommand):
             return
         if any(x in value_new.casefold() for x in ('1','e','0','all')):
             self.setEnabled(      cfg.Default['Enabled'])
-        if any(x in value_new.casefold() for x in ('2','d','0','all')):
+        if any(x in value_new.casefold() for x in ('2','s','0','all')):
             self.setSizeDivisor(  cfg.Default['SizeDivisor'])
         if any(x in value_new.casefold() for x in ('3','g','0','all')):
             self.setMaxGlob(      cfg.Default['MaxGlob'])
@@ -205,7 +205,7 @@ class ConfigureStatusBarExtended(ApplicationCommand):
             self.setSymbolPane(   cfg.Default['SymbolPane'])
         if any(x in value_new.casefold() for x in ('7','h','0','all')):
             self.setSymbolHiddenF(cfg.Default['SymbolHiddenF'])
-        if any(x in value_new.casefold() for x in ('8','o','0','all')):
+        if any(x in value_new.casefold() for x in ('8','d','0','all')):
             self.setHideDotfile(  cfg.Default['HideDotfile'])
         if any(x in value_new.casefold() for x in ('9','j','0','all')):
             self.setJustify(      cfg.Default['Justify'])

--- a/statusbarextended_config/__init__.py
+++ b/statusbarextended_config/__init__.py
@@ -438,7 +438,11 @@ class ConfigureStatusBarExtended(ApplicationCommand):
                 show_alert("You entered\n" + value_new +'\n'\
                     + "I parsed it as " + value_new_fmt +'\n'\
                     + "but the only acceptable values are:\n" +_tsep+ "\n" +_fsep)
+        value_old = self.cfgCurrent['HideDotfile']
         self.cfgCurrent['HideDotfile'] = True if value_new_fmt in _t else False
+        value_new = self.cfgCurrent['HideDotfile']
+        if value_old != value_new:
+            show_alert("You've changed HideDotfile value, please restart fman\nfor the change to take effect!")
 
     def setJustify(self, value_default):
         value_cfg_in    = self.cfgCurrent['Justify']

--- a/statusbarextended_dotfile/__init__.py
+++ b/statusbarextended_dotfile/__init__.py
@@ -1,0 +1,31 @@
+# Override the Core hidden file filter to be able to hide non-hidden dotfiles on Windows
+
+from fman import load_json, PLATFORM, DATA_DIRECTORY
+import core.commands
+from fman.url import as_human_readable as as_path, as_url, join, splitscheme, basename
+from fman.fs import exists
+
+config_file       = 'StatusBarExtended ('+PLATFORM+').json'
+user_settings_url = join(as_url(DATA_DIRECTORY),'Plugins','User','Settings')
+f_url             = join(user_settings_url, config_file)
+f_path            = as_path(f_url)
+key               = 'HideDotfile'
+if exists(f_url):
+    cfgCurrent = load_json(f_path) # read the path directly and without any validation as at this moment in module loading load_json doesn't seem to know about 'User/Settings' path and cfg.loadConfig() would instead of loading the existing config create a new file at the wrong location ('Third-party/StatusBarExtended' folder)
+
+    # Replace Core file filter with Core + dotfiles (if 'HideDotfile' is set)
+    if PLATFORM == 'Windows' \
+        and type(cfgCurrent) is type(dict()) \
+        and key in cfgCurrent \
+        and cfgCurrent[key] == True:
+        _core_hidden_file_filter = core.commands._hidden_file_filter
+        def _hidden_file_filter(url):
+            core_return = _core_hidden_file_filter(url)
+            if core_return and not is_dotfile(url): # regular and not dotfile
+                return True
+            else:                                   # hidden or is_dotfile
+                return False
+        core.commands._hidden_file_filter = _hidden_file_filter
+
+def is_dotfile(url):
+    return basename(url).startswith('.')

--- a/toggleselection/__init__.py
+++ b/toggleselection/__init__.py
@@ -2,7 +2,7 @@
 # combined filesize for selected files and the number of selected folders/files
 
 from fman import DirectoryPaneCommand, DirectoryPaneListener, load_json, save_json, PLATFORM
-from core.commands.util import is_hidden
+import core.commands
 from fman.url import splitscheme
 import statusbarextended        as SBE
 import statusbarextended_config as SBEcfg
@@ -27,28 +27,7 @@ class _CorePaneCommand(DirectoryPaneCommand): # copy from core/commands/__init__
         self.pane.move_cursor_end(      toggle_selection)
 
     def toggle_hidden_files(self):
-        _toggle_hidden_files(self.pane, not _is_showing_hidden_files(self.pane))
-def _toggle_hidden_files(pane, value):
-    if value:
-        pane._remove_filter(_hidden_file_filter)
-    else:
-        pane._add_filter(_hidden_file_filter)
-    _get_pane_info(pane)['show_hidden_files'] = value
-    save_json('Panes.json')
-def _is_showing_hidden_files(pane):
-    return _get_pane_info(pane)['show_hidden_files']
-def _get_pane_info(pane):
-    settings = load_json('Panes.json', default=[])
-    default = {'show_hidden_files': False}
-    pane_index = pane.window.get_panes().index(pane)
-    for _ in range(pane_index - len(settings) + 1):
-        settings.append(default.copy())
-    return settings[pane_index]
-def _hidden_file_filter(url):
-    if PLATFORM == 'Mac' and url == 'file:///Volumes':
-        return True
-    scheme, path = splitscheme(url)
-    return scheme != 'file://' or not is_hidden(path)
+        core.commands._toggle_hidden_files(self.pane, not core.commands._is_showing_hidden_files(self.pane))
 
 def _get_opposite_pane(pane):
     panes = pane.window.get_panes()

--- a/toggleselection/__init__.py
+++ b/toggleselection/__init__.py
@@ -3,7 +3,6 @@
 
 from fman import DirectoryPaneCommand, DirectoryPaneListener, load_json, save_json, PLATFORM
 import core.commands
-from fman.url import splitscheme
 import statusbarextended        as SBE
 import statusbarextended_config as SBEcfg
 


### PR DESCRIPTION
Think this is the last config option I wanted to add — for the labels themselves

Also finally fixed that nasty `ValueError` bug! Don't understand why, but importing and calling the `core.commands` functions directly seemed to do the trick (alternative that worked: copy one more command [InitHiddenFilesFilter](https://github.com/fman-users/Core/blob/20d328a67fbd13d1adcf840f8b158040bfb3730f/core/commands/__init__.py#L1031)  from Core and call it ourselves, but that would require disabling it in the Core (last time I tried it without disabling the Core command the pane wouldn't show any files at all as the filters seemed to just duplicate)
there might be something in the closed source `pane._remove_filter` that leads to this or maybe just some general object thingy I don't get, but anyway, but glad it's sorted out :sparkles::sparkles:! (even though we need to use a private Core function)

**FYI:** since each bug fix is structured as a minor version bump, don't forget to make 4 tags/releases as well if you want the links to work correctly 

## [v0.4.4 — 15.08.2021]
  [ v0.4.4 — 15.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.4
  - __Added__
    + :sparkles: `HideDotfile` now also affects the pane list, not just the status bar

## [v0.4.3 — 14.08.2021]
  [ v0.4.3 — 14.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.3
  - __Fixed__
    + :beetle: `ValueError` on the first `Toggle hidden files` if a pane is _launched_ with hidden files _hidden_

## [v0.4.2 — 14.08.2021]
  [ v0.4.2 — 14.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.2
  - __Fixed__
    + :beetle: glob meta-characters `[` `]` `*` `?` in paths (e.g. `[A--_B]`) crash glob or lead to wrong results

## [v0.4.1 — 13.08.2021]
  [ v0.4.1 — 13.08.2021]: https://github.com/kek91/StatusBarExtended/releases/tag/v0.4.1
  - __Added__
    + :sparkles: User-configurable options for the Folder/File/Size labels 

        |     Option    	|  Default                 	|                  Description              	|
        | :-------------	| :-----------------------:	| :-----------------------------------------	|
        | Label         	| `Dirs:` `Files:` `Size:` 	|  `Folder`/`File`/`Size` labels            	|
        | Hide0Label    	| `True`                   	|  Hide labels when 0 folders/files           |
